### PR TITLE
Correção de bug para habilitar testes com Modular

### DIFF
--- a/flutter_modular_test/lib/flutter_modular_test.dart
+++ b/flutter_modular_test/lib/flutter_modular_test.dart
@@ -3,17 +3,21 @@ library flutter_modular_test;
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
-void initModule(Module module, {List<Bind<Object>> replaceBinds = const [], bool initialModule = false}) {
-  for (var i = 0; i < module.binds.length; i++) {
-    final item = module.binds[i];
+void initModule(Module module,
+    {List<Bind<Object>> replaceBinds = const [], bool initialModule = false}) {
+  final bindModules = [...module.getProcessBinds()];
+
+  for (var i = 0; i < bindModules.length; i++) {
+    final item = bindModules[i];
     var dep = (replaceBinds).firstWhere((dep) {
       return item.runtimeType == dep.runtimeType;
     }, orElse: () => BindEmpty());
     if (dep is! BindEmpty) {
-      module.binds[i] = dep;
+      bindModules[i] = dep;
     }
   }
-  //module.changeBinds(changedList);
+
+  module.changeBinds(bindModules);
   if (initialModule) {
     Modular.init(module);
   } else {
@@ -21,7 +25,8 @@ void initModule(Module module, {List<Bind<Object>> replaceBinds = const [], bool
   }
 }
 
-void initModules(List<Module> modules, {List<Bind<Object>> replaceBinds = const []}) {
+void initModules(List<Module> modules,
+    {List<Bind<Object>> replaceBinds = const []}) {
   for (var module in modules) {
     initModule(module, replaceBinds: replaceBinds);
   }

--- a/flutter_modular_test/pubspec.yaml
+++ b/flutter_modular_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_modular_test
 description: Smart project structure with dependency injection and route management
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/Flutterando/modular
 
 environment:


### PR DESCRIPTION
## Objetivo

O ModularTest tem um bug que não permite realizar os testes no ambiente

## Execução

Correção do `initModule` para  permitir a correta substituição dos  módulos no `bind`.